### PR TITLE
[feature] add verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The following kernel compression formats can be automatically detected: XZ, LZMA
 ## Advanced usage
 
 You can also obtain a text-only output of the kernel's symbol names, addresses and types through using the `kallsyms-finder` utility, also bundled with this tool. The format of its output will be similar to the `/proc/kallsyms` procfs file.
+The optional _verbose_ mode displays additional information about the ELF.
 
 Some parameters that should be automatically inferred by the tool (such as the instruction set or base address) may be overriden in case of issue. The full specification of the arguments allowing to do that is presented below:
 
@@ -112,6 +113,7 @@ positional arguments:
 
 optional arguments:
   -h, --help           show this help message and exit
+  --verbose, -v        Include meta information in output
   --bit-size BIT_SIZE  Force overriding the input kernel bit size, providing
                        32 or 64 bit (rather than auto-detect)
 

--- a/vmlinux_to_elf/architecture_detecter.py
+++ b/vmlinux_to_elf/architecture_detecter.py
@@ -151,8 +151,6 @@ def guess_architecture(binary : bytes) -> ArchitectureName:
     
     architecture_to_number_of_prologues :  Dict[ArchitectureName, int] = Counter()
     
-    begin_time = time()
-    
     for architecture, prologue in architecture_to_prologue_regex.items():
         
         architecture_to_number_of_prologues[architecture] = len(findall(prologue, binary,  flags = DOTALL))
@@ -161,7 +159,5 @@ def guess_architecture(binary : bytes) -> ArchitectureName:
 
     if number_of_prologues < 100:
         raise ArchitectureGuessError('The architecture could not be guessed successfully')
-
-    print('[+] Guessed architecture: %s successfully in %s seconds' % (best_architecture_guess.name, time() - begin_time))
 
     return best_architecture_guess

--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -953,7 +953,7 @@ if __name__ == '__main__':
         "or stripped ELF kernel file, and print these to the standard output with their " +
         "addresses")
 
-    args.add_argument('--verbose', '-v', action = 'store_true', help = "Include meta information in output", type = bool)
+    args.add_argument('--verbose', '-v', action = 'store_true', help = "Include meta information in output")
     args.add_argument('input_file', help = "Path to the kernel file to extract symbols from")
     args.add_argument('--bit-size', help = 'Force overriding the input kernel ' +
         'bit size, providing 32 or 64 bit (rather than auto-detect)', type = int)

--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -164,7 +164,8 @@ class KallsymsFinder:
         We'll find kallsyms_token_table and infer the rest
     """
     
-    def __init__(self, kernel_img : bytes, bit_size : int = None):
+    def __init__(self, kernel_img : bytes, bit_size : int = None, verbose : bool = False):
+        self.verbose = verbose
         
         self.kernel_img = kernel_img
         
@@ -218,8 +219,9 @@ class KallsymsFinder:
         
         self.version_string = regex_match.group(0).decode('ascii')
         self.version_number = regex_match.group(1).decode('ascii')
-        
-        print('[+] Version string:', self.version_string)
+
+        if self.verbose:
+            print('[+] Version string:', self.version_string)
         #print('[+] Other related strings containing the version number:', findall(b'[ -~]*%s[ -~]*' % regex_match.group(1), self.kernel_img))
         #print('[+] Architecture string:', search(b'mod_unload[ -~]+', self.kernel_img).group(0))
     
@@ -303,8 +305,9 @@ class KallsymsFinder:
         position += -position % 4
         
         self.kallsyms_token_table__offset = position
-        
-        print('[+] Found kallsyms_token_table at file offset 0x%08x' % self.kallsyms_token_table__offset)
+
+        if self.verbose:
+            print('[+] Found kallsyms_token_table at file offset 0x%08x' % self.kallsyms_token_table__offset)
     
     
     def find_kallsyms_token_index(self):
@@ -368,8 +371,9 @@ class KallsymsFinder:
             self.is_big_endian = True
         
             self.kallsyms_token_index__offset = position + found_position_for_be_value
-        
-        print('[+] Found kallsyms_token_index at file offset 0x%08x' % self.kallsyms_token_index__offset)
+
+        if self.verbose:
+            print('[+] Found kallsyms_token_index at file offset 0x%08x' % self.kallsyms_token_index__offset)
     
 
     def find_kallsyms_names_uncompressed(self):
@@ -415,10 +419,10 @@ class KallsymsFinder:
         if self.number_of_symbols < 100:
             
             raise KallsymsNotFoundException('No embedded symbol table found in this kernel')
-        
-        print('[+] Kernel symbol names found at file offset', hex(ksymtab_match.start(0)))
-        
-        print('[+] Found %d uncompressed kernel symbols (end at 0x%08x)' % (self.number_of_symbols, position))
+
+        if self.verbose:
+            print('[+] Kernel symbol names found at file offset', hex(ksymtab_match.start(0)))
+            print('[+] Found %d uncompressed kernel symbols (end at 0x%08x)' % (self.number_of_symbols, position))
         
         self.end_of_kallsyms_names_uncompressed = position
 
@@ -505,8 +509,9 @@ class KallsymsFinder:
         
         
         self.kallsyms_markers__offset = position
-        
-        print('[+] Found kallsyms_markers at file offset 0x%08x' % position)
+
+        if self.verbose:
+            print('[+] Found kallsyms_markers at file offset 0x%08x' % position)
         
     
     def find_kallsyms_markers(self):
@@ -591,8 +596,9 @@ class KallsymsFinder:
         
         
         self.kallsyms_markers__offset = position
-        
-        print('[+] Found kallsyms_markers at file offset 0x%08x' % position)
+
+        if self.verbose:
+            print('[+] Found kallsyms_markers at file offset 0x%08x' % position)
     
     def find_kallsyms_names(self):
         
@@ -683,15 +689,13 @@ class KallsymsFinder:
                     self.kallsyms_names__offset -= 4
                 else:
                     raise ValueError('Could not find kallsyms_names')
-        
-        print('[+] Found kallsyms_names at file offset 0x%08x' % self.kallsyms_names__offset)
-        
+
         position = (self.kallsyms_names__offset - MAX_ALIGNMENT - 20) + needle
-        
-        
         self.kallsyms_num_syms__offset = position
-        
-        print('[+] Found kallsyms_num_syms at file offset 0x%08x' % position)
+
+        if self.verbose:
+            print('[+] Found kallsyms_names at file offset 0x%08x' % self.kallsyms_names__offset)
+            print('[+] Found kallsyms_num_syms at file offset 0x%08x' % position)
     
     """
         This method defines self.kallsyms_addresses_or_offsets__offset,
@@ -806,8 +810,9 @@ class KallsymsFinder:
 
             if self.has_base_relative:
                 number_of_negative_items = len([offset for offset in tentative_addresses_or_offsets if offset < 0])
-                
-                print('[i] Negative offsets overall: %g %%' % (number_of_negative_items / len(tentative_addresses_or_offsets) * 100))
+
+                if self.verbose:
+                    print('[i] Negative offsets overall: %g %%' % (number_of_negative_items / len(tentative_addresses_or_offsets) * 100))
             
                 if number_of_negative_items / len(tentative_addresses_or_offsets) >= 0.5: # Non-absolute symbols are negative with CONFIG_KALLSYMS_ABSOLUTE_PERCPU
                     self.has_absolute_percpu = True
@@ -821,16 +826,17 @@ class KallsymsFinder:
                 self.has_absolute_percpu = False
 
             number_of_null_items = len([address for address in tentative_addresses_or_offsets if address == 0])
-            
-            print('[i] Null addresses overall: %g %%' % (number_of_null_items / len(tentative_addresses_or_offsets) * 100))
+
+            if self.verbose:
+                print('[i] Null addresses overall: %g %%' % (number_of_null_items / len(tentative_addresses_or_offsets) * 100))
         
             if number_of_null_items / len(tentative_addresses_or_offsets) >= 0.2: # If there are too much null symbols we have likely tried to parse the wrong integer size
                 
                 if can_skip:
                     continue
                 
-            
-            print('[+] Found %s at file offset 0x%08x' % ('kallsyms_offsets' if self.has_base_relative else 'kallsyms_addresses', position))
+            if self.verbose:
+                print('[+] Found %s at file offset 0x%08x' % ('kallsyms_offsets' if self.has_base_relative else 'kallsyms_addresses', position))
             
             self.kernel_addresses = tentative_addresses_or_offsets
             
@@ -924,11 +930,11 @@ class KallsymsFinder:
         for symbol_name in self.symbol_names:
             
             symbol_types.add(symbol_name[0])
-        
-        print('Symbol types', '=>', sorted(symbol_types))
-        print()
-        
-        
+
+        if self.verbose:
+            print('Symbol types', '=>', sorted(symbol_types))
+            print()
+
         # Print symbols, in a fashion similar to /proc/kallsyms
         
         for symbol_address, symbol_name in zip(self.kernel_addresses, self.symbol_names):
@@ -946,7 +952,8 @@ if __name__ == '__main__':
     args = ArgumentParser(description = "Find the kernel's embedded symbol table from a raw " +
         "or stripped ELF kernel file, and print these to the standard output with their " +
         "addresses")
-    
+
+    args.add_argument('--verbose', type=bool, action='store_true', help="Include meta information in output", default=True)
     args.add_argument('input_file', help = "Path to the kernel file to extract symbols from")
     args.add_argument('--bit-size', help = 'Force overriding the input kernel ' +
         'bit size, providing 32 or 64 bit (rather than auto-detect)', type = int)
@@ -957,7 +964,7 @@ if __name__ == '__main__':
     with open(args.input_file, 'rb') as kernel_bin:
         
         try:
-            kallsyms = KallsymsFinder(obtain_raw_kernel_from_file(kernel_bin.read()), args.bit_size)
+            kallsyms = KallsymsFinder(obtain_raw_kernel_from_file(kernel_bin.read()), args.bit_size, args.verbose)
         
         except ArchitectureGuessError:
            exit('[!] The architecture of your kernel could not be guessed ' +

--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -953,7 +953,7 @@ if __name__ == '__main__':
         "or stripped ELF kernel file, and print these to the standard output with their " +
         "addresses")
 
-    args.add_argument('--verbose', type=bool, action='store_true', help="Include meta information in output", default=True)
+    args.add_argument('--verbose', '-v', action = 'store_true', help = "Include meta information in output", type = bool)
     args.add_argument('input_file', help = "Path to the kernel file to extract symbols from")
     args.add_argument('--bit-size', help = 'Force overriding the input kernel ' +
         'bit size, providing 32 or 64 bit (rather than auto-detect)', type = int)

--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -229,6 +229,8 @@ class KallsymsFinder:
         
         self.architecture : ArchitectureName = guess_architecture(self.kernel_img)
         # self.architecture  =  ArchitectureName.mipsle # DEBUG
+        if self.verbose:
+            print('[+] Guessed architecture: %s successfully' % (self.architecture.name))
 
         self.elf_machine,  self.is_64_bits,  self.is_big_endian = architecture_name_to_elf_machine_and_is64bits_and_isbigendian[self.architecture]
 


### PR DESCRIPTION
I had the problem that for a batch task, I only needed the symbol printed to `stdout`. Therefore, I made the meta information optional.