### PR TITLE
Remove left-over debug code

### DIFF
--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -838,8 +838,6 @@ class KallsymsFinder:
             print('[+] Found %s at file offset 0x%08x' % ('kallsyms_offsets' if self.has_base_relative else 'kallsyms_addresses', position))
             
             self.kernel_addresses = tentative_addresses_or_offsets
-            
-            break # DEBUG
         
     def parse_symbol_table(self):
         


### PR DESCRIPTION
Without this change the code will always assume has_base_relative=True
which will break kernels that are not built with
CONFIG_KALLSYMS_BASE_RELATIVE.