### PR TITLE
Fix in the relocation table detection

### DIFF
--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -297,7 +297,7 @@ class KallsymsFinder:
                         break
 
                 if possible_offset != -1:
-                    offset = possible_offset + 8
+                    offset = possible_offset - 8
 
                 continue
 


### PR DESCRIPTION
In case we found the rela entry we should move word size backwards as we want offset to point to the beginning of the symbol entry