### PR TITLE
[log] Switch out ``print()`` for ``log()``

### DIFF
--- a/vmlinux_to_elf/architecture_detecter.py
+++ b/vmlinux_to_elf/architecture_detecter.py
@@ -7,7 +7,7 @@ from argparse import Namespace
 from enum import IntEnum
 from io import BytesIO
 from time import time
-
+import logging
 
 """
     Guess the architecture of a given binary.
@@ -189,6 +189,6 @@ def guess_architecture(binary : bytes) -> ArchitectureName:
     if not architecture_guess:
         raise ArchitectureGuessError('The architecture could not be guessed successfully')
 
-    print('[+] Guessed architecture: %s successfully in %.2f seconds' % (architecture_guess.name, time() - begin_time))
+    logging.info('[+] Guessed architecture: %s successfully in %.2f seconds' % (architecture_guess.name, time() - begin_time))
 
     return architecture_guess

--- a/vmlinux_to_elf/elf_symbolizer.py
+++ b/vmlinux_to_elf/elf_symbolizer.py
@@ -3,7 +3,7 @@
 from re import search, IGNORECASE
 from argparse import Namespace
 from io import BytesIO
-
+import logging
 
 """
     The ElfSymbolizer class, defined in this file, gathers information from
@@ -198,7 +198,7 @@ class ElfSymbolizer():
             
             kernel.serialize(fd)
         
-        print('[+] Successfully wrote the new ELF kernel to %s' % output_file)
+        logging.info('[+] Successfully wrote the new ELF kernel to %s' % output_file)
     
     
 

--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Tuple
 from argparse import ArgumentParser
 from io import BytesIO
 from enum import Enum
-from sys import argv
+from sys import argv, stdout
 import logging
 
 try:
@@ -1086,7 +1086,7 @@ class KallsymsFinder:
         
 if __name__ == '__main__':
 
-    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    logging.basicConfig(stream=stdout, level=logging.INFO, format='%(message)s')
 
     args = ArgumentParser(description = "Find the kernel's embedded symbol table from a raw " +
         "or stripped ELF kernel file, and print these to the standard output with their " +

--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -1069,7 +1069,7 @@ class KallsymsFinder:
             
             symbol_types.add(symbol_name[0])
         
-        logging.info('Symbol types => {0:s}'.format(sorted(symbol_types)))
+        logging.info('Symbol types => %r' % sorted(symbol_types))
         logging.info('')
         
         
@@ -1077,15 +1077,16 @@ class KallsymsFinder:
         
         for symbol_address, symbol_name in zip(self.kernel_addresses, self.symbol_names):
             
-            logging.info(
-                '%016x' % symbol_address if self.is_64_bits
-                else '%08x' % symbol_address,
+            logging.info( "{0:s} {1:s} {2:s}".format(
+                '%016x' % symbol_address if self.is_64_bits else '%08x' % symbol_address,
                 symbol_name[0], # The symbol type
                 symbol_name[1:] # The symbol name itself
-            )
+            ))
         
         
 if __name__ == '__main__':
+
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
 
     args = ArgumentParser(description = "Find the kernel's embedded symbol table from a raw " +
         "or stripped ELF kernel file, and print these to the standard output with their " +

--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -554,7 +554,7 @@ class KallsymsFinder:
             
             raise KallsymsNotFoundException('No embedded symbol table found in this kernel')
         
-        logging.info('[+] Kernel symbol names found at file offset', hex(ksymtab_match.start(0)))
+        logging.info('[+] Kernel symbol names found at file offset 0x%08x' % ksymtab_match.start(0))
         
         logging.info('[+] Found %d uncompressed kernel symbols (end at 0x%08x)' % (self.number_of_symbols, position))
         

--- a/vmlinux_to_elf/main.py
+++ b/vmlinux_to_elf/main.py
@@ -2,7 +2,7 @@
 #-*- encoding: Utf-8 -*-
 from argparse import ArgumentParser
 from io import BytesIO
-from sys import argv
+from sys import argv, stdout
 import logging
 
 try:
@@ -17,7 +17,7 @@ except ImportError:
 
 if __name__ == '__main__':
 
-    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    logging.basicConfig(stream=stdout, level=logging.INFO, format='%(message)s')
     
     args = ArgumentParser(description = 'Turn a raw or compressed kernel binary, ' +
         'or a kernel ELF without symbols, into a fully analyzable ELF whose ' +

--- a/vmlinux_to_elf/main.py
+++ b/vmlinux_to_elf/main.py
@@ -3,7 +3,7 @@
 from argparse import ArgumentParser
 from io import BytesIO
 from sys import argv
-
+import logging
 
 try:
     from vmlinuz_decompressor import obtain_raw_kernel_from_file
@@ -16,6 +16,8 @@ except ImportError:
     from vmlinux_to_elf.architecture_detecter import ArchitectureGuessError
 
 if __name__ == '__main__':
+
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
     
     args = ArgumentParser(description = 'Turn a raw or compressed kernel binary, ' +
         'or a kernel ELF without symbols, into a fully analyzable ELF whose ' +
@@ -47,7 +49,7 @@ if __name__ == '__main__':
     if ((args.e_machine is not None and args.bit_size is None) or
         (args.e_machine is None and args.bit_size is not None)):
         
-        print('[!] Please specify both an addressing bit size ' +
+        logging.error('[!] Please specify both an addressing bit size ' +
             'and the ELF "e_machine" field, or neither for ' +
             'auto-detection')
         

--- a/vmlinux_to_elf/tests.py
+++ b/vmlinux_to_elf/tests.py
@@ -28,6 +28,7 @@ from os.path import dirname, realpath, exists
 from traceback import print_exc
 from os import makedirs
 from re import sub
+from sys import stdout
 import logging
 
 SCRIPT_DIR = dirname(realpath(__file__))
@@ -40,7 +41,7 @@ def slugify(file_path):
 
 if __name__ == '__main__':
 
-    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    logging.basicConfig(stream=stdout, level=logging.INFO, format='%(message)s')
 
     if not exists(TEST_KERNELS_PATH):
         

--- a/vmlinux_to_elf/tests.py
+++ b/vmlinux_to_elf/tests.py
@@ -28,6 +28,7 @@ from os.path import dirname, realpath, exists
 from traceback import print_exc
 from os import makedirs
 from re import sub
+import logging
 
 SCRIPT_DIR = dirname(realpath(__file__))
 TEST_KERNELS_PATH = realpath(SCRIPT_DIR + '/test_kernels.txt')
@@ -50,7 +51,7 @@ if __name__ == '__main__':
 
     for file_name in filter(None, map(str.strip, open(TEST_KERNELS_PATH, 'r'))):
         
-        print('Testing ' + file_name)
+        logging.info('Testing ' + file_name)
         
         with open(file_name, 'rb') as fd:
             contents = fd.read()
@@ -59,7 +60,7 @@ if __name__ == '__main__':
         try:
             ElfSymbolizer(raw_data, ELF_KERNELS_OUTPUT_PATH + '/' + slugify(file_name) + '.elf')
         except Exception:
-            print('=> No symbols!')
+            logging.error('=> No symbols!')
             print_exc()
         
         

--- a/vmlinux_to_elf/tests.py
+++ b/vmlinux_to_elf/tests.py
@@ -40,6 +40,8 @@ def slugify(file_path):
 
 if __name__ == '__main__':
 
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
+
     if not exists(TEST_KERNELS_PATH):
         
         exit(('[!] In order to use this script, please ' +

--- a/vmlinux_to_elf/vmlinuz_decompressor.py
+++ b/vmlinux_to_elf/vmlinuz_decompressor.py
@@ -8,6 +8,7 @@ from struct import unpack
 from typing import Union
 from re import search
 import importlib
+import logging
 
 """
     How to detect a vmlinuz file?
@@ -133,10 +134,10 @@ def try_decompress_at(input_file : bytes, offset : int) -> bytes:
                 LZ4Decompressor = importlib.import_module('lz4.frame')
                 
             except ModuleNotFoundError:
-                print('ERROR: This kernel requres LZ4 decompression.')
-                print('       But "lz4" python package does not found.')
-                print('       Example installation command: "sudo pip3 install lz4"')
-                print()
+                logging.error('ERROR: This kernel requres LZ4 decompression.')
+                logging.error('       But "lz4" python package does not found.')
+                logging.error('       Example installation command: "sudo pip3 install lz4"')
+                logging.error()
                 return
 
             context = LZ4Decompressor.create_decompression_context()
@@ -146,7 +147,7 @@ def try_decompress_at(input_file : bytes, offset : int) -> bytes:
         pass
     
     if decoded and len(decoded) > 0x1000:
-        print(('[+] Kernel successfully decompressed in-memory (the offsets that ' +
+        logging.info(('[+] Kernel successfully decompressed in-memory (the offsets that ' +
             'follow will be given relative to the decompressed binary)'))
     
         return decoded


### PR DESCRIPTION
``logging.log()`` is easier to configure and suppress than ``print()``, which is mainly done by redirecting ``stdout``.
This PR makes it easier to use ``vmlinux-to-elf`` in another python project rather than as a standalone script