### PR TITLE
Lzo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ System-wide installation:
 
 ```bash
 sudo apt install python3-pip
-sudo pip3 install --upgrade lz4 zstandard git+https://github.com/marin-m/vmlinux-to-elf
+sudo pip3 install --upgrade lz4 zstandard git+https://github.com/clubby789/python-lzo git+https://github.com/marin-m/vmlinux-to-elf
 ```
 
 ## Features
@@ -62,7 +62,7 @@ It supports kernels from version 2.6.10 (December 2004) until now. Only kernels 
 
 For raw kernels, the following architectures can be detected (using magics from [binwalk](https://github.com/ReFirmLabs/binwalk/blob/master/src/binwalk/magic/binarch)): MIPSEL, MIPSEB, ARMEL, ARMEB, PowerPC, SPARC, x86, x86-64, ARM64, MIPS64, SuperH, ARC.
 
-The following kernel compression formats can be automatically detected: XZ, LZMA, GZip, BZ2, LZ4, Zstd. Support for LZO may be added upon request.
+The following kernel compression formats can be automatically detected: XZ, LZMA, GZip, BZ2, LZ4, LZO and Zstd.
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Usage:
 ./vmlinux-to-elf <input_kernel.bin> <output_kernel.elf>
 ```
 
-System-wide installation:
+System-wide installation (the second command may not be needed as PIP should find the dependencies within the `setup.py` file):
 
 ```bash
 sudo apt install python3-pip
-sudo pip3 install --upgrade lz4 zstandard git+https://github.com/clubby789/python-lzo git+https://github.com/marin-m/vmlinux-to-elf
+sudo pip3 install --upgrade lz4 zstandard git+https://github.com/clubby789/python-lzo@b4e39df
+sudo pip3 install --upgrade git+https://github.com/marin-m/vmlinux-to-elf
 ```
 
 ## Features

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ setup(name='vmlinux-to-elf',
       author='Marin Moulinier',
       author_email='',
       url='https://github.com/marin-m/vmlinux-to-elf',
+      install_requires=['lz4', 'zstandard'
+        'python-lzo @ git+https://github.com/clubby789/python-lzo@b4e39df'],
       packages=['vmlinux_to_elf', 'vmlinux_to_elf.utils'],
       scripts=['vmlinux-to-elf', 'kallsyms-finder']
      )

--- a/vmlinux_to_elf/vmlinuz_decompressor.py
+++ b/vmlinux_to_elf/vmlinuz_decompressor.py
@@ -239,7 +239,7 @@ def try_decompress_at(input_file : bytes, offset : int) -> bytes:
             except ModuleNotFoundError:
                 logging.error('ERROR: This kernel requres LZO decompression.')
                 logging.error('       But "python-lzo" python package was not found.')
-                logging.error('       Example installation command: "sudo pip3 install git+https://github.com/clubby789/python-lzo"')
+                logging.error('       Example installation command: "sudo pip3 install git+https://github.com/clubby789/python-lzo@b4e39df"')
                 logging.error()
                 return
             buf = BytesIO(input_file[offset:])


### PR DESCRIPTION
I originally tried to write this against [python-lzo](https://pypi.org/project/python-lzo/) but had issues with getting it to accept the format the kernel was compressed with.

The module I use here works better, but is incompatible with Python 3. I've made a [PR](https://github.com/ir193/python-lzo/pull/4) to add support to master, but until then it will have to be installed from my fork.

This has been tested against a custom built kernel with `tinyconfig + CONFIG_KERNEL_LZO  + CONFIG_KALLSYMS`