### PR TITLE
Fix performance of find_kallsyms_num_syms

### DIFF
--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -734,16 +734,14 @@ class KallsymsFinder:
         while position > 0 and self.kernel_img[position] == 0:
             position -= 1
         
-        memory_to_search = bytes(self.kernel_img[position - MAX_ARRAY_SIZE:
-            position])
-        
-        needle = memory_to_search.rfind(b'\x00' * self.offset_table_element_size)
+
+        needle = self.kernel_img.rfind(b'\x00' * self.offset_table_element_size, position - MAX_ARRAY_SIZE, position)
         
         if needle == -1:
             
             raise ValueError('Could not find kallsyms_markers')
         
-        position = (position - MAX_ARRAY_SIZE) + needle
+        position = needle
         
         position -= position % self.offset_table_element_size
         
@@ -786,17 +784,16 @@ class KallsymsFinder:
     def find_kallsyms_num_syms(self):
         
         needle = -1
-        
+
+        token_table = self.get_token_table()
+        possible_symbol_types = [i.value for i in KallsymsSymbolType]
+
+        dp = []
+
         while needle == -1:
             
             position =  self.kallsyms_names__offset
-            
-            # Count the number of symbols
-            
-            num_symbols = 0
-            
-            symbol_counting_position = position
-            
+
             # Check whether this looks like the correct symbol
             # table, first depending on the beginning of the
             # first symbol (as this is where an uncertain gap
@@ -806,38 +803,33 @@ class KallsymsFinder:
             # another function) if an exotic kind of symbol is
             # found somewhere else than in the first entry.
 
-            token_table = self.get_token_table()
-            first_token_index_of_first_name = self.kernel_img[symbol_counting_position + 1]
+            first_token_index_of_first_name = self.kernel_img[position + 1]
             first_token_of_first_name = token_table[first_token_index_of_first_name]
-            possible_symbol_types = [i.value for i in KallsymsSymbolType]
-            
+
             if (not (first_token_of_first_name[0].lower() in 'uvw' and
                 first_token_of_first_name[0] in possible_symbol_types) and
                 first_token_of_first_name[0].upper() not in possible_symbol_types):
-                    
-                if 0 <= self.kallsyms_names__offset - 4 < self.kallsyms_markers__offset:
-                    self.kallsyms_names__offset -= 4
-                else:
+
+                self.kallsyms_names__offset -= 4
+                if self.kallsyms_names__offset < 0:
                     raise ValueError('Could not find kallsyms_names')
                 continue
-            
-            while True:
-            
-                symbol_size = self.kernel_img[symbol_counting_position]
-                
-                if not symbol_size:
-                    break
-                
-                symbol_counting_position += symbol_size + 1
-                num_symbols += 1
-                
-                if not (0 <= symbol_counting_position < self.kallsyms_markers__offset):
-                    break
-            
-            if num_symbols < 256 or symbol_counting_position > self.kallsyms_markers__offset:
-                if 0 <= self.kallsyms_names__offset - 4 < self.kallsyms_markers__offset:
-                    self.kallsyms_names__offset -= 4
+
+            # Bottom-up DP approach to calculate number of symbols given starting position
+            for i in range(len(dp), self.kallsyms_markers__offset - position + 1):
+                symbol_size = self.kernel_img[self.kallsyms_markers__offset - i]
+                next_i = i - symbol_size - 1
+                if symbol_size == 0:  # End of chain
+                    dp.append(0)
+                elif next_i < 0 or dp[next_i] == -1:  # If chain would exceed kallsyms_markers, mark as invalid
+                    dp.append(-1)
                 else:
+                    dp.append(dp[next_i] + 1)
+            num_symbols = dp[-1]
+
+            if num_symbols < 256:
+                self.kallsyms_names__offset -= 4
+                if self.kallsyms_names__offset < 0:
                     raise ValueError('Could not find kallsyms_names')
                 continue
             
@@ -854,21 +846,17 @@ class KallsymsFinder:
             MAX_ALIGNMENT = 256
             
             encoded_num_symbols = pack(endianness_marker + long_size_marker, num_symbols)
-            
-            memory_to_search = bytes(self.kernel_img[self.kallsyms_names__offset - MAX_ALIGNMENT - 20:
-                self.kallsyms_names__offset])
-            
-            needle = memory_to_search.rfind(encoded_num_symbols)
+
+            needle = self.kernel_img.rfind(encoded_num_symbols, max(0, self.kallsyms_names__offset - MAX_ALIGNMENT - 20), self.kallsyms_names__offset)
             
             if needle == -1: # There may be no padding between kallsyms_names and kallsyms_num_syms, if the alignment is already correct: in this case: try other offsets for "kallsyms_names"
-                if 0 <= self.kallsyms_names__offset - 4 < self.kallsyms_markers__offset:
-                    self.kallsyms_names__offset -= 4
-                else:
+                self.kallsyms_names__offset -= 4
+                if self.kallsyms_names__offset < 0:
                     raise ValueError('Could not find kallsyms_names')
         
         logging.info('[+] Found kallsyms_names at file offset 0x%08x' % self.kallsyms_names__offset)
         
-        position = (self.kallsyms_names__offset - MAX_ALIGNMENT - 20) + needle
+        position = needle
         
         
         self.kallsyms_num_syms__offset = position


### PR DESCRIPTION
This PR aims to improve performance of `find_kallsyms_num_syms` by changing the while loop that calculates the number of symbols to a bottom-up dynamic programming approach to avoid recalculating the same information multiple times.

In testing, I've gotten the `find_kallsyms_num_syms` method from taking around ~4 seconds down to ~0.3 seconds.

The behaviour hasn't changed, so should generate the exact same output as before.