### PR TITLE
fix kernel_text_candidate detect error

### DIFF
--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -255,7 +255,8 @@ class KallsymsFinder:
         R_AARCH64_RELATIVE = 0x403
         elf64_rela = []
         minimal_heuristic_count = 1000
-        minimal_kernel_va = 0xFFFFFF8008080000
+        # minimal_kernel_va = 0xFFFFFF8008080000
+        minimal_kernel_va = 0xFFFF800000000000
         maximal_kernel_va = 0xFFFFFFFFFFFFFFFF
         kernel_text_candidate = maximal_kernel_va
 


### PR DESCRIPTION
The problem was found on version 5.10, the following is the information of System.map

0000000000000000 A _kernel_flags_le_hi32
0000000000000000 A _kernel_size_le_hi32
000000000000000a A _kernel_flags_le_lo32
0000000000000200 A PECOFF_FILE_ALIGNMENT
000000000045ed48 A __rela_size
00000000007caa00 A __pecoff_data_rawsize
0000000000860000 A __pecoff_data_size
0000000001530000 A __efistub_primary_entry_offset
0000000001682e20 A __rela_offset
0000000001daaa00 A __efistub_kernel_size
0000000001e40000 A _kernel_size_le_lo32
ffff800010000000 t __efistub__text
ffff800010000000 t _head
ffff800010000000 T _text
ffff800010000040 t pe_header
ffff800010000044 t coff_header
ffff800010000058 t optional_header
ffff800010000070 t extra_header_fields
ffff8000100000f8 t section_table
ffff800010020000 T __irqentry_text_start
ffff800010020000 T _stext
.......
