### PR TITLE
Optimize ElfSymbolizer

### DIFF
--- a/vmlinux_to_elf/elf_symbolizer.py
+++ b/vmlinux_to_elf/elf_symbolizer.py
@@ -157,17 +157,23 @@ class ElfSymbolizer():
             """
             Uses binary search to quickly find the section which the address belongs to
             """
+            # Set baseline and roofline hypotheses, expressed in
+            # section table indexes:
             lower_range, upper_range = 0, len(sections) - 1
+            # Wait for the hypotheses to converge
             while lower_range < upper_range:
+                # Mean operation to pick a new tentative hypothesis
+                # (add one to ensure to ceil-round the upper
+                # hypothesis in case of a difference of 1)
                 middle = (lower_range + upper_range + 1) // 2
-                if sections[middle].section_header.sh_addr <= address:
-                    lower_range = middle
+                if sections[middle].section_header.sh_addr <= address: # Test the hypothesis
+                    lower_range = middle # Use the hypothesis as a baseline
                 else:
-                    upper_range = middle - 1
+                    upper_range = middle - 1 # Disqualify the hypothesis
             if (sections[lower_range].section_header.sh_addr <= address <=
                 sections[lower_range].section_header.sh_addr +
                 sections[lower_range].section_header.sh_size):
-                return sections[lower_range]
+                return sections[lower_range] # Select the best hypothesis if it qualifies
             return None
 
         elf_symbol_class = {

--- a/vmlinux_to_elf/elf_symbolizer.py
+++ b/vmlinux_to_elf/elf_symbolizer.py
@@ -153,19 +153,21 @@ class ElfSymbolizer():
             kernel.sections += [symtab, strtab, shstrtab]
 
         sections = sorted([i for i in kernel.sections if i.section_header.sh_addr > 0], key=lambda x: x.section_header.sh_addr)
-        def _find_section(addr):
+        def _find_section(address):
             """
             Uses binary search to quickly find the section which the address belongs to
             """
-            mi, ma = 0, len(sections)-1
-            while mi < ma:
-                mid = (mi+ma+1)//2
-                if addr >= sections[mid].section_header.sh_addr:
-                    mi = mid
+            lower_range, upper_range = 0, len(sections) - 1
+            while lower_range < upper_range:
+                middle = (lower_range + upper_range + 1) // 2
+                if sections[middle].section_header.sh_addr <= address:
+                    lower_range = middle
                 else:
-                    ma = mid-1
-            if sections[mi].section_header.sh_addr <= addr <= sections[mi].section_header.sh_addr + sections[mi].section_header.sh_size:
-                return sections[mi]
+                    upper_range = middle - 1
+            if (sections[lower_range].section_header.sh_addr <= address <=
+                sections[lower_range].section_header.sh_addr +
+                sections[lower_range].section_header.sh_size):
+                return sections[lower_range]
             return None
 
         elf_symbol_class = {


### PR DESCRIPTION
As seen in PR #45, ElfSymbolizer, can be rather slow due to an inefficient way of calculating which section a symbol belongs to, when there are many sections. 

This PR optimizes the search by turning it into a binary search of the sections rather than a linear search. In testing, run time of the for loop has been reduced from 25 minutes to 5 seconds when running against [this kernel image](https://ctftime.org/task/14383).

The only side-effect of this patch is that when two sections are positioned right up against each other, and the address is on the boundary, it will now prefer the latter rather than the former, though this is probably more correct anyways.