### PR TITLE
Revert "fix kernel_text_candidate detect error"

### DIFF
--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -255,8 +255,7 @@ class KallsymsFinder:
         R_AARCH64_RELATIVE = 0x403
         elf64_rela = []
         minimal_heuristic_count = 1000
-        # minimal_kernel_va = 0xFFFFFF8008080000
-        minimal_kernel_va = 0xFFFF800000000000
+        minimal_kernel_va = 0xFFFFFF8008080000
         maximal_kernel_va = 0xFFFFFFFFFFFFFFFF
         kernel_text_candidate = maximal_kernel_va
 


### PR DESCRIPTION
Reverts marin-m/vmlinux-to-elf#42
I'm sorry that I find some error when kallsyms-finder on pixel2xl-andorid-10 boot.img.
I need more test on this.