### PR TITLE
Fix broken --e-machine and --bit-size command line options

### DIFF
--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -244,7 +244,8 @@ class KallsymsFinder:
             otherwise
         """
 
-        if ArchitectureName.aarch64 != self.architecture:
+        # FIX: architecture is not set when guess_architecture() wasn't called
+        if hasattr(self, 'architecture') and ArchitectureName.aarch64 != self.architecture:
 
             # I've tested this only for ARM64
             return False

--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -245,7 +245,7 @@ class KallsymsFinder:
         """
 
         # FIX: architecture is not set when guess_architecture() wasn't called
-        if hasattr(self, 'architecture') and ArchitectureName.aarch64 != self.architecture:
+        if not hasattr(self, 'architecture') or ArchitectureName.aarch64 != self.architecture:
 
             # I've tested this only for ARM64
             return False


### PR DESCRIPTION
I noticed that in most recent version --e-machine and --bit-size options are not working as they should because of inaccurate safety check in `find_elf64_rela` function code. 

Here's an example before proposed fix:
```
$ ./vmlinux-to-elf vmlinuz-4.1.0-2-amd64 output.elf
[+] Kernel successfully decompressed in-memory (the offsets that follow will be given relative to the decompressed binary)
[+] Version string: Linux version 4.1.0-2-amd64 (debian-kernel@lists.debian.org) (gcc version 4.9.3 (Debian 4.9.3-3) ) #1 SMP Debian 4.1.6-1 (2015-08-23)
[!] The architecture of your kernel could not be guessed successfully. Please specify the --e-machine and --bit-size arguments manually (use --help for their precise specification).
$ ./vmlinux-to-elf --e-machine 62 --bit-size 64 vmlinuz-4.1.0-2-amd64 output.elf
[+] Kernel successfully decompressed in-memory (the offsets that follow will be given relative to the decompressed binary)
[+] Version string: Linux version 4.1.0-2-amd64 (debian-kernel@lists.debian.org) (gcc version 4.9.3 (Debian 4.9.3-3) ) #1 SMP Debian 4.1.6-1 (2015-08-23)
Traceback (most recent call last):
  File "./vmlinux-to-elf", line 63, in <module>
    ElfSymbolizer(
  File "/vagrant_home/_encrypted/data/_PoC/lkm_kif/vmlinux-to-elf/vmlinux_to_elf/elf_symbolizer.py", line 44, in __init__
    kallsyms_finder = KallsymsFinder(file_contents, bit_size)
  File "/vagrant_home/_encrypted/data/_PoC/lkm_kif/vmlinux-to-elf/vmlinux_to_elf/kallsyms_finder.py", line 187, in __init__
    self.find_elf64_rela()
  File "/vagrant_home/_encrypted/data/_PoC/lkm_kif/vmlinux-to-elf/vmlinux_to_elf/kallsyms_finder.py", line 247, in find_elf64_rela
    if ArchitectureName.aarch64 != self.architecture:
AttributeError: 'KallsymsFinder' object has no attribute 'architecture'
```

... and after the fix:
```
$ ./vmlinux-to-elf --e-machine 62 --bit-size 64 vmlinuz-4.1.0-2-amd64 output.elf
[+] Kernel successfully decompressed in-memory (the offsets that follow will be given relative to the decompressed binary)
[+] Version string: Linux version 4.1.0-2-amd64 (debian-kernel@lists.debian.org) (gcc version 4.9.3 (Debian 4.9.3-3) ) #1 SMP Debian 4.1.6-1 (2015-08-23)
[+] Found kallsyms_token_table at file offset 0x00908648
[+] Found kallsyms_token_index at file offset 0x009089a0
[+] Found kallsyms_markers at file offset 0x009082c0
[+] Found kallsyms_names at file offset 0x008b6868
[+] Found kallsyms_num_syms at file offset 0x008b6860
[i] Null addresses overall: 0.00696306 %
[+] Found kallsyms_addresses at file offset 0x0087e6c8
[+] Successfully wrote the new ELF kernel to output.elf
```

PS: thank you for awesome tool!