### PR TITLE
Linux kernel 6.4+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ In standard Linux 6.2 kernels, `kallsyms` arrays are encoded in the following or
 # `kallsyms_token_table`
 # `kallsyms_token_index`
 
+For Linux 6.4+ kernels, this layout is changed to: 
+
+# `kallsyms_num_syms`
+# `kallsyms_names`
+# `kallsyms_markers`
+# `kallsyms_token_table`
+# `kallsyms_token_index`
+# `kallsyms_addresses` (or `kallsyms_offsets` + `kallsyms_relative_base`)
+# `kallsyms_seqs_of_names`
+
 While these are parsed in the following order by `vmlinux-to-elf`'s parsing algorithm:
 
 # `kallsyms_token_table` (before-last structure)


### PR DESCRIPTION
From [this commit](https://github.com/torvalds/linux/commit/404bad70fcf7cb1a36198581e6904637f3c36846), the `kallsyms` arrays layout has been changed to: 
- kallsyms_num_syms
- kallsyms_names
- kallsyms_markers
- kallsyms_token_table
- kallsyms_token_index
- kallsyms_addresses (or kallsyms_offsets + kallsyms_relative_base)
- kallsyms_seqs_of_names

This commit adds support for this layout change. 