### PR TITLE
fix: Use raw strings for regex expressions

### DIFF
--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -218,7 +218,7 @@ class KallsymsFinder:
     
     def find_linux_kernel_version(self):
         
-        regex_match = search(b'Linux version (\d+\.[\d.]*\d)[ -~]+', self.kernel_img)
+        regex_match = search(rb'Linux version (\d+\.[\d.]*\d)[ -~]+', self.kernel_img)
         
         if not regex_match:
             
@@ -537,7 +537,7 @@ class KallsymsFinder:
 
         # Find the length byte-separated symbol names
         
-        ksymtab_match = search(b'(?:[\x05-\x23][TWtbBrRAdD][a-z0-9_.]{4,34}){14}', self.kernel_img)
+        ksymtab_match = search(rb'(?:[\x05-\x23][TWtbBrRAdD][a-z0-9_.]{4,34}){14}', self.kernel_img)
         
         if not ksymtab_match:
             
@@ -562,7 +562,7 @@ class KallsymsFinder:
                 position + 1 + self.kernel_img[position]
             ]
             
-            if not match(b'^[\x21-\x7e]+$', symbol_name_and_type):
+            if not match(rb'^[\x21-\x7e]+$', symbol_name_and_type):
                 break
                         
             position += 1 + self.kernel_img[position]

--- a/vmlinux_to_elf/tests.py
+++ b/vmlinux_to_elf/tests.py
@@ -37,7 +37,7 @@ ELF_KERNELS_OUTPUT_PATH = realpath(SCRIPT_DIR + '/tests_output')
 
 def slugify(file_path):
     
-    return sub('[^a-z0-9]+', '-', file_path.lower()).strip('-')
+    return sub(r'[^a-z0-9]+', '-', file_path.lower()).strip('-')
 
 if __name__ == '__main__':
 

--- a/vmlinux_to_elf/vmlinuz_decompressor.py
+++ b/vmlinux_to_elf/vmlinuz_decompressor.py
@@ -277,7 +277,7 @@ def obtain_raw_kernel_from_file(input_file: bytes) -> bytes:
         if decompressed_data:
             return decompressed_data
     
-    if not search(b'Linux version (\d+\.[\d.]*\d)[ -~]+', input_file):  # No kernel version string found
+    if not search(rb'Linux version (\d+\.[\d.]*\d)[ -~]+', input_file):  # No kernel version string found
 
         # If not successful, scan for compression signatures in the whole document
         for possible_signature in Signature.Compressed:


### PR DESCRIPTION
Not annotating the strings as raw results in invalid escape sequences. Due to python shenanigans this did not actually matter in practice. But as of python3.12 this causes a SyntaxWarning and will cause an error in the future.

Reference: https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences