### PR TITLE
Override relative

### DIFF
--- a/vmlinux_to_elf/elf_symbolizer.py
+++ b/vmlinux_to_elf/elf_symbolizer.py
@@ -77,10 +77,13 @@ class ElfSymbolizer():
             
             if base_address is not None:
                 progbits.section_header.sh_addr = base_address
+                logging.info(f"[+] Explicit base address given ({progbits.section_header.sh_addr:x})")
             elif kallsyms_finder.kernel_text_candidate:
                 progbits.section_header.sh_addr = kallsyms_finder.kernel_text_candidate
+                logging.info(f"[+] Base address using kernel_text_candidate ({progbits.section_header.sh_addr:x})")
             else:
                 progbits.section_header.sh_addr = first_symbol_virtual_address & 0xfffffffffffff000
+                logging.info(f"[+] Base address fallback, using first_symbol_virtual_address ({progbits.section_header.sh_addr:x})")
             
             progbits.section_contents = file_contents
             


### PR DESCRIPTION
When analyzing a kernel recently, this tool was reporting relative offsets in the kallsyms table when actually they were absolute addresses.  This pull-request adds a switch to force absolute addresses and also adds some heuristics to suggest when to use that switch.