### PR TITLE
Consistent default between kallsyms_finder.py and main.py (vmlinux-to-elf)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build/
 *.pyc
 __pycache__/
 .~lock.*
+
+**/*.egg-info/
+**/.idea/

--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -169,7 +169,7 @@ class KallsymsFinder:
         We'll find kallsyms_token_table and infer the rest
     """
     
-    def __init__(self, kernel_img : bytes, bit_size : int = None, override_relative_base : bool = True):
+    def __init__(self, kernel_img : bytes, bit_size : int = None, override_relative_base : bool = False):
         
         self.override_relative_base = override_relative_base
         self.kernel_img = kernel_img


### PR DESCRIPTION
Recent commit 611bb0c changed the constructor signature of `KallsymsFinder` by adding a third optional argument `override_relative_base`
```
def __init__(self, kernel_img : bytes, bit_size : int = None, override_relative_base : bool = True):
```
The default constructor value for said argument is True, however, the default for the `__main__` is False, i.e. the user has to explicitly pass the argument to call the constructor with True. See the `kallsyms_finder.py:__main__` invocation
```
kallsyms = KallsymsFinder(obtain_raw_kernel_from_file(kernel_bin.read()), args.bit_size, args.override_relative)
```
Now, when running `vmlinux-to-elf` the call to create the `KallsymsFinder` object ignores the third parameter, thus the constructor default 'True' is in effect, see `ElfSymbolizer:__init__:49`
```
kallsyms_finder = KallsymsFinder(file_contents, bit_size)
```
Since the default behavior when running `kallsyms_finder.py` is to call the constructor explicitly with False for third parameter, I suggest that the default constructor value whould be False rather than True. This would make the calling convention between `kallsyms_finder.py` and `main.py` (vmlinux-to-elf) consistent. An alternative change would be to expose the command line argument in `kallsyms_finder.py` to `vmlinux-to-elf` as well (or it could be added at a later time).