### PR TITLE
Consider lower possible _text start addresses for newer kernels v6.5.x >=

### DIFF
--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -259,7 +259,7 @@ class KallsymsFinder:
         R_AARCH64_RELATIVE = 0x403
         elf64_rela = []
         minimal_heuristic_count = 1000
-        minimal_kernel_va = 0xFFFFFF8008080000
+        minimal_kernel_va = 0xFFFFC00080000000
         maximal_kernel_va = 0xFFFFFFFFFFFFFFFF
         kernel_text_candidate = maximal_kernel_va
 


### PR DESCRIPTION
There is an assumed lowest possible value for `minimal_kernel_va`, which normally is correct. However, on some arm64 v6.5.x >= kernels the beginning of _text is at an even lower value than before (assumed).

The effect is that the _text base address is set to the assumed 'max' at 0xFFFFFFFFFFFFFFFF, which causes the symbol values to end up all over the map. There is no change in the logic as the format seems to be the same at least for v6.5.x - v6.12.x. Note that I am not sure of any detrimental effects, i.e. earlier kernel version and/or on different architectures, with this patch which sets a lower bound for the minimal value, but I wouldn't believe so.