### PR TITLE
Move python-lzo dependency to minilzo on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ Usage:
 ./vmlinux-to-elf <input_kernel.bin> <output_kernel.elf>
 ```
 
-System-wide installation (the second command may not be needed as PIP should find the dependencies within the `setup.py` file):
+System-wide installation:
 
 ```bash
-sudo apt install python3-pip liblzo2-dev
-sudo pip3 install --upgrade lz4 zstandard git+https://github.com/clubby789/python-lzo@b4e39df
-sudo pip3 install --upgrade git+https://github.com/marin-m/vmlinux-to-elf
+sudo apt install pipx
+sudo pipx install git+https://github.com/marin-m/vmlinux-to-elf
 ```
 
 ## Features

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,7 @@ setup(name='vmlinux-to-elf',
       author='Marin Moulinier',
       author_email='',
       url='https://github.com/marin-m/vmlinux-to-elf',
-      install_requires=['lz4', 'zstandard',
-        'python-lzo @ git+https://github.com/clubby789/python-lzo@b4e39df'],
+      install_requires=['lz4', 'zstandard', 'minilzo'],
       packages=['vmlinux_to_elf', 'vmlinux_to_elf.utils'],
       scripts=['vmlinux-to-elf', 'kallsyms-finder']
      )

--- a/vmlinux_to_elf/vmlinuz_decompressor.py
+++ b/vmlinux_to_elf/vmlinuz_decompressor.py
@@ -110,8 +110,6 @@ class SingleGzipReader(_GzipReader):
         self.__new_member = new_value
         
 
-missing_deps = set()  # List of missing dependencies that could be used by this kernel
-
 """
     Try to decompress a file at a given offset, without
     knowing the compression algorithm

--- a/vmlinux_to_elf/vmlinuz_decompressor.py
+++ b/vmlinux_to_elf/vmlinuz_decompressor.py
@@ -216,7 +216,7 @@ def try_decompress_at(input_file : bytes, offset : int) -> bytes:
     except Exception:
         pass
     
-    if decoded and decoded.startswith(b'\x7fELF') and len(decoded) > 0x1000:
+    if decoded and 0 in decoded[:32] and len(decoded) > 0x1000:
         logging.info(('[+] Kernel successfully decompressed in-memory (the offsets that ' +
             'follow will be given relative to the decompressed binary)'))
     

--- a/vmlinux_to_elf/vmlinuz_decompressor.py
+++ b/vmlinux_to_elf/vmlinuz_decompressor.py
@@ -216,7 +216,7 @@ def try_decompress_at(input_file : bytes, offset : int) -> bytes:
     except Exception:
         pass
     
-    if decoded and len(decoded) > 0x1000:
+    if decoded and decoded.startswith(b'\x7fELF') and len(decoded) > 0x1000:
         logging.info(('[+] Kernel successfully decompressed in-memory (the offsets that ' +
             'follow will be given relative to the decompressed binary)'))
     


### PR DESCRIPTION
If we're going to eventually publish the project to PyPI (See #73), we need to remove dependencies on GitHub. I've removed the current dependency on [clubby789/python-lzo](https://github.com/clubby789/python-lzo) and renamed it to minilzo, which is published to PyPI.
Supersedes #72.
Also fixes #62.