### PR TITLE
Add support for big symbols

### DIFF
--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -705,7 +705,8 @@ class KallsymsFinder:
                     continue
 
                 for i in range(1, len(entries)):
-                    if entries[i-1]+0x200 > entries[i] or entries[i-1]+0x4000 < entries[i]:
+                    # kallsyms_names entries are at least 2 bytes and at most 0x3FFF bytes long
+                    if entries[i-1]+0x200 >= entries[i] or entries[i-1]+0x400000 < entries[i]:
                         break
                 else:
                     logging.info('[+] Found kallsyms_markers at file offset 0x%08x' % position)
@@ -732,7 +733,7 @@ class KallsymsFinder:
         for i in range(1, len(kallsyms_markers_entries)):
             curr = kallsyms_markers_entries[i]
             last = kallsyms_markers_entries[i-1]
-            if last+0x200 > curr or last+0x4000 < curr:
+            if last+0x200 >= curr or last+0x400000 < curr:
                 kallsyms_markers_entries = kallsyms_markers_entries[:i]
                 break
 
@@ -746,7 +747,6 @@ class KallsymsFinder:
         
         
         self.kallsyms_names__offset = position
-        
         # Guessing continues in the function below (in order to handle the
         # absence of padding)
         
@@ -793,9 +793,14 @@ class KallsymsFinder:
             # The loop ends with the number of symbols for the current position in the last entry of dp.
 
             for i in range(len(dp), self.kallsyms_markers__offset - position + 1):
-                symbol_size = self.kernel_img[self.kallsyms_markers__offset - i]
-                next_i = i - symbol_size - 1
-                if symbol_size == 0:  # Last entry of the symbol table
+                curr = self.kernel_img[self.kallsyms_markers__offset - i]
+                if curr & 0x80:
+                    # "Big" symbol
+                    symbol_size = (curr&0x7F | (self.kernel_img[self.kallsyms_markers__offset - i + 1]<<7)) + 2
+                else:
+                    symbol_size = curr + 1
+                next_i = i - symbol_size
+                if curr == 0:  # Last entry of the symbol table
                     dp.append(0)
                 elif next_i < 0 or dp[next_i] == -1:  # If table would exceed kallsyms_markers, mark as invalid
                     dp.append(-1)
@@ -830,7 +835,7 @@ class KallsymsFinder:
                 if self.kallsyms_names__offset < 0:
                     raise ValueError('Could not find kallsyms_names')
         
-        logging.info('[+] Found kallsyms_names at file offset 0x%08x' % self.kallsyms_names__offset)
+        logging.info('[+] Found kallsyms_names at file offset 0x%08x (%d symbols)' % (self.kallsyms_names__offset, self.num_symbols))
         
         position = needle
         
@@ -1083,6 +1088,9 @@ class KallsymsFinder:
             
             length = self.kernel_img[position]
             position += 1
+            if length & 0x80:
+                length = length & 0x7f | (self.kernel_img[position] << 7)
+                position += 1
             
             for i in range(length):
                 

--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -706,7 +706,7 @@ class KallsymsFinder:
 
                 for i in range(1, len(entries)):
                     # kallsyms_names entries are at least 2 bytes and at most 0x3FFF bytes long
-                    if entries[i-1]+0x200 >= entries[i] or entries[i-1]+0x400000 < entries[i]:
+                    if entries[i-1]+0x200 >= entries[i] or entries[i-1]+0x40000 < entries[i]:
                         break
                 else:
                     logging.info('[+] Found kallsyms_markers at file offset 0x%08x' % position)
@@ -727,13 +727,16 @@ class KallsymsFinder:
         endianness_marker = '>' if self.is_big_endian else '<'
             
         long_size_marker = {2: 'H', 4: 'I', 8: 'Q'}[self.offset_table_element_size]
+
+        # Estimate kallsyms_markers length. Limit to 3000 for kernels with kallsyms_seqs_of_names
+        num_of_kallsyms_markers_entries = (self.kallsyms_token_table__offset - self.kallsyms_markers__offset) // self.offset_table_element_size
         
-        kallsyms_markers_entries = unpack_from(endianness_marker + '3000' + long_size_marker, self.kernel_img, self.kallsyms_markers__offset)
+        kallsyms_markers_entries = unpack_from(endianness_marker + str(min(3000, num_of_kallsyms_markers_entries)) + long_size_marker, self.kernel_img, self.kallsyms_markers__offset)
 
         for i in range(1, len(kallsyms_markers_entries)):
             curr = kallsyms_markers_entries[i]
             last = kallsyms_markers_entries[i-1]
-            if last+0x200 >= curr or last+0x400000 < curr:
+            if last+0x200 >= curr or last+0x40000 < curr:
                 kallsyms_markers_entries = kallsyms_markers_entries[:i]
                 break
 
@@ -801,7 +804,7 @@ class KallsymsFinder:
                     symbol_size = curr + 1
                 next_i = i - symbol_size
                 if curr == 0:  # Last entry of the symbol table
-                    dp.append(0)
+                    dp.append(0 if i < 64 else -1)
                 elif next_i < 0 or dp[next_i] == -1:  # If table would exceed kallsyms_markers, mark as invalid
                     dp.append(-1)
                 else:

--- a/vmlinux_to_elf/kallsyms_finder.py
+++ b/vmlinux_to_elf/kallsyms_finder.py
@@ -804,7 +804,7 @@ class KallsymsFinder:
                     symbol_size = curr + 1
                 next_i = i - symbol_size
                 if curr == 0:  # Last entry of the symbol table
-                    dp.append(0 if i < 64 else -1)
+                    dp.append(0 if i <= 256 else -1)
                 elif next_i < 0 or dp[next_i] == -1:  # If table would exceed kallsyms_markers, mark as invalid
                     dp.append(-1)
                 else:


### PR DESCRIPTION
kallsyms_names has support for symbols longer than 128 chars using ULEB128 encoding ([here](https://github.com/torvalds/linux/blob/068a56e5/scripts/kallsyms.c#L392)). 
This assumes that kernels before this change didn't have symbols of length 128-255, which is unlikely since it's only really Rust that gets these long symbols.

Fixes #61 