### PR TITLE
Define SHT_ANDROID_RELR to process Android kernel

### DIFF
--- a/vmlinux_to_elf/utils/elf.py
+++ b/vmlinux_to_elf/utils/elf.py
@@ -322,6 +322,10 @@ class SH_TYPE(IntEnum):
     SHT_MIPS_REGINFO = 0x70000006
     SHT_MIPS_ABIFLAGS = 0x7000002a
 
+    # Android's experimental support for SHT_RELR sections.
+    # https://android.googlesource.com/platform/bionic/+/b7feec74547f84559a1467aca02708ff61346d2a/libc/include/elf.h#512
+    SHT_ANDROID_RELR = 0x6fffff00 # Relocation entries; only offsets.
+
 
 class SH_FLAGS(IntEnum):
     


### PR DESCRIPTION
It fails to process a recent Android's Generic Kernel Image due to undefined SH_TYPE:

```
ValueError: 1879047936 is not a valid SH_TYPE
```

This commit adds the SHT_ANDROID_RELR to fix this issue. The code originates from LLVM.

https://github.com/llvm/llvm-project/blob/a21521a4efacba405964767a8c2280b40aa68536/llvm/include/llvm/BinaryFormat/ELF.h#L1191