### PR TITLE
7.0 support (#96)

### DIFF
--- a/vmlinux_to_elf/core/kallsyms.py
+++ b/vmlinux_to_elf/core/kallsyms.py
@@ -1240,19 +1240,25 @@ class KallsymsFinder:
         # https://github.com/torvalds/linux/commit/a081b5789255d27b76cd2cbab85676b2a31dbde1
         if kernel_major >= 7:
             heuristic_search_parameters = [
-                (False, True, True), (False, False, False)
+                (False, True, True),
+                (False, False, False),
             ]
         else:
             heuristic_search_parameters = [
-                (True, False, True), (False, False, False)
+                (True, False, True),
+                (False, False, False)
                 if likely_has_base_relative
-                else [(False, False, True), (False, False, False)]
+                else [(False, False, True), (False, False, False)],
             ]
             # Only makes sense in the non-pc-relative case
             if self.override_relative_base:
                 heuristic_search_parameters = [(False, False, False)]
 
-        for has_base_relative, pc_relative, can_skip in heuristic_search_parameters:
+        for (
+            has_base_relative,
+            pc_relative,
+            can_skip,
+        ) in heuristic_search_parameters:
             address_byte_size = (
                 8 if likely_is_64_bits else self.offset_table_element_size
             )
@@ -1496,21 +1502,23 @@ class KallsymsFinder:
                 # reading the vaddr from the first segment.
                 # this should be at fixed offsets, but calculating this manually
                 # in case that ever turns out to be invalid.
-                addr_marker = {4: "I", 8: "Q"}[address_byte_size]
-                phdr_offset, = unpack_from(
+                addr_marker = {4: 'I', 8: 'Q'}[address_byte_size]
+                (phdr_offset,) = unpack_from(
                     endianness_marker + addr_marker,
                     self.kernel_img,
-                    0x18 + address_byte_size
+                    0x18 + address_byte_size,
                 )
                 phdr_offset += 0x10 if self.is_64_bits else 0x08
-                base_address, = unpack_from(
+                (base_address,) = unpack_from(
                     endianness_marker + addr_marker,
                     self.kernel_img,
-                    phdr_offset
+                    phdr_offset,
                 )
                 tentative_addresses_or_offsets = [
                     base_address + offset - _text + idx * offset_byte_size
-                    for idx, offset in enumerate(tentative_addresses_or_offsets)
+                    for idx, offset in enumerate(
+                        tentative_addresses_or_offsets
+                    )
                 ]
 
                 self.has_absolute_percpu = False

--- a/vmlinux_to_elf/core/kallsyms.py
+++ b/vmlinux_to_elf/core/kallsyms.py
@@ -56,6 +56,12 @@ from vmlinux_to_elf.kernel_db.database import (
     
     ^ This format should be supported.
     
+    In v7.0 (2026), the format removed the relative base.
+    
+    https://github.com/torvalds/linux/commit/a081b5789255d27b76cd2cbab85676b2a31dbde1
+    
+    ^ This format should be supported.
+    
     Its 2002-2004 (versions 2.5.54-2.6.9) implementation code with basic "stem
     compression" can be found here for parsing:
     https://github.com/sarnobat/knoppix/blob/master/kernel/kallsyms.c
@@ -1206,7 +1212,7 @@ class KallsymsFinder:
         likely_has_base_relative = False
 
         if (
-            kernel_major > 4
+            (kernel_major > 4 and kernel_major < 7)
             or (kernel_major == 4 and kernel_minor >= 6)
             and 'ia64' not in self.version_string.lower()
             and 'itanium' not in self.version_string.lower()
@@ -1227,17 +1233,30 @@ class KallsymsFinder:
 
         # Try different possibilities heuristically:
 
-        heuristic_search_parameters = (
-            [(True, True), (False, False)]
-            if likely_has_base_relative
-            else [(False, True), (False, False)]
-        )
-        if self.override_relative_base:
-            heuristic_search_parameters = [(False, False)]
-        for has_base_relative, can_skip in heuristic_search_parameters:
+        heuristic_search_parameters = []
+        # In 7.0, the format was changed to be relative from the slot in
+        # kallsyms_offsets.
+        # This applies to all 64 bit kernels, and every relocatable kernel.
+        # https://github.com/torvalds/linux/commit/a081b5789255d27b76cd2cbab85676b2a31dbde1
+        if kernel_major >= 7:
+            heuristic_search_parameters = [
+                (False, True, True), (False, False, False)
+            ]
+        else:
+            heuristic_search_parameters = [
+                (True, False, True), (False, False, False)
+                if likely_has_base_relative
+                else [(False, False, True), (False, False, False)]
+            ]
+            # Only makes sense in the non-pc-relative case
+            if self.override_relative_base:
+                heuristic_search_parameters = [(False, False, False)]
+
+        for has_base_relative, pc_relative, can_skip in heuristic_search_parameters:
             address_byte_size = (
                 8 if likely_is_64_bits else self.offset_table_element_size
             )
+
             offset_byte_size = min(
                 4, self.offset_table_element_size
             )  # Size of an assembly ".long"
@@ -1246,7 +1265,7 @@ class KallsymsFinder:
                 # Linux 6.4 or later place (kallsyms_addresses)/(kallsyms_offsets+kallsyms_relative_base) after kallsyms_token_index.
 
                 # The align_size is defined at (https://github.com/torvalds/linux/blob/v6.4/scripts/kallsyms.c#L390).
-                align_size = 8 if likely_is_64_bits else 4
+                align_size = 8 if likely_is_64_bits and not pc_relative else 4
 
                 position = self.kallsyms_token_index_end__offset
                 position += -position % align_size
@@ -1255,7 +1274,8 @@ class KallsymsFinder:
                     position += self.num_symbols * offset_byte_size
                     position += -position % align_size
                     position += address_byte_size
-
+                elif pc_relative:
+                    position += self.num_symbols * offset_byte_size
                 else:
                     position += self.num_symbols * address_byte_size
 
@@ -1306,7 +1326,9 @@ class KallsymsFinder:
                     position -= offset_byte_size
 
                 position -= self.num_symbols * offset_byte_size
-
+            elif pc_relative:
+                position -= self.num_symbols * offset_byte_size
+                self.has_base_relative = False
             else:
                 self.has_base_relative = False
 
@@ -1322,6 +1344,9 @@ class KallsymsFinder:
                 long_size_marker = {2: 'h', 4: 'i'}[
                     offset_byte_size
                 ]  # Offsets may be negative, contrary to addresses
+            elif pc_relative:
+                # Only 32bit relative offsets.
+                long_size_marker = 'i'
             else:
                 long_size_marker = {2: 'H', 4: 'I', 8: 'Q'}[address_byte_size]
 
@@ -1449,7 +1474,46 @@ class KallsymsFinder:
                         offset + self.relative_base_address
                         for offset in tentative_addresses_or_offsets
                     ]
+            elif pc_relative:
+                # We are making the assumption that _text is the first element
+                # for the PC relative kernels.
+                # Technically, it is probably the third or so member of the
+                # list depending on architecture, with the first few being
+                # srso_alias_untrain_ret and _stext on x86-64, but they all
+                # share the same address.
+                _text = tentative_addresses_or_offsets[0]
 
+                # Checking if this kernel has an absolute addresses or not.
+                # They are relative to kallsyms_offset, so around that the
+                # offsets switch from negative to positive values, which is the
+                # heursitic we are using to detect relocatable kernels.
+                # Sadly this is the only reasonable place to check for this, as
+                # we need the addresses first.
+                last = tentative_addresses_or_offsets[-1]
+                if not (_text <= 0 and last >= 0) and can_skip:
+                    continue
+
+                # reading the vaddr from the first segment.
+                # this should be at fixed offsets, but calculating this manually
+                # in case that ever turns out to be invalid.
+                addr_marker = {4: "I", 8: "Q"}[address_byte_size]
+                phdr_offset, = unpack_from(
+                    endianness_marker + addr_marker,
+                    self.kernel_img,
+                    0x18 + address_byte_size
+                )
+                phdr_offset += 0x10 if self.is_64_bits else 0x08
+                base_address, = unpack_from(
+                    endianness_marker + addr_marker,
+                    self.kernel_img,
+                    phdr_offset
+                )
+                tentative_addresses_or_offsets = [
+                    base_address + offset - _text + idx * offset_byte_size
+                    for idx, offset in enumerate(tentative_addresses_or_offsets)
+                ]
+
+                self.has_absolute_percpu = False
             else:
                 self.has_absolute_percpu = False
 


### PR DESCRIPTION
For #96, I reworked my draft patch to now hopefully in a better state. Might be a bit overcommented, and I'm sure there is nicer way to write out the logic to discover the first segments vaddr.

* Added an extra option to the heuristic search, for the new format. post 7.0 it now only considers the pc-relative logic + the non-relocated kernels (what you mentioned in the issue that I missed).
* Detecting if its the pc-relative format by checking if the first one is negative and the last symbol is positive.
* Discovers the base address by looking at the first segment and using its vaddr.

Tested with the following [kernels](https://drive.google.com/drive/folders/1m1WfX-b9klc0g51SP4CJPleya90jzKwR?usp=sharing), checking I could access a symbol with radare2:
* x86_64 6.19 - to avoid breakage
* x86_64 7.0 - Main target
* x86_32 7.0 Relocatable - Secondary target
* aarch64 7.0.5 from Arch Linux ARM
* x86_32 7.0 Nonrelocatable - to check the bailout code